### PR TITLE
Few fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
     <groovy codeStyle="LEGACY" />
   </component>
   <component name="PhpWorkspaceProjectConfiguration" backward_compatibility_performed="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,9 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/dev-emacs-plus_main.iml" filepath="$PROJECT_DIR$/.idea/modules/dev-emacs-plus_main.iml" group="emacs-plus" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/dev-emacs-plus_test.iml" filepath="$PROJECT_DIR$/.idea/modules/dev-emacs-plus_test.iml" group="emacs-plus" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/emacs-plus.iml" filepath="$PROJECT_DIR$/.idea/modules/emacs-plus.iml" group="emacs-plus" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/emacs-plus.iml" filepath="$PROJECT_DIR$/.idea/modules/emacs-plus.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/emacs-plus.main.iml" filepath="$PROJECT_DIR$/.idea/modules/emacs-plus.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/emacs-plus.test.iml" filepath="$PROJECT_DIR$/.idea/modules/emacs-plus.test.iml" />
     </modules>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ intellij {
 }
 
 publishPlugin {
-    token = project.property("publishToken", "")
-    channels = project.property("publishChannels", "").split(',')
+    token = hasProperty('publishToken') ? publishToken : ''
+    channels = hasProperty('publishChannels') ? publishChannels.split(',') : []
 }
 
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,19 @@
 plugins {
-  id "org.jetbrains.intellij" version "0.4.16"
+  id "org.jetbrains.intellij" version "1.14.1"
 }
 
 group 'com.cursive-ide'
-version '0.3.900'
+version '0.3.901'
 
 intellij {
-  version '2019.3.3'
-  pluginName 'emacs-plus'
-  updateSinceUntilBuild false
+  version = '2019.3.3'
+  pluginName = 'emacs-plus'
+  updateSinceUntilBuild = false
 }
 
 publishPlugin {
-  token publishToken
-  channels publishChannels.split(',')
+    token = project.property("publishToken", "")
+    channels = project.property("publishChannels", "").split(',')
 }
 
 apply plugin: 'java'

--- a/src/main/java/com/mulgasoft/emacsplus/actions/wrapper/KeyboardQuit.java
+++ b/src/main/java/com/mulgasoft/emacsplus/actions/wrapper/KeyboardQuit.java
@@ -18,7 +18,6 @@ import java.awt.*;
 public class KeyboardQuit extends EmacsPlusWrapper {
   public KeyboardQuit() {
     super(new Handler(getWrappedHandler("EditorEscape")));
-    setInjectedContext(true);
   }
 
   private static class Handler extends EditorActionHandler {

--- a/src/main/resources/Keymap_EmacsPlus.xml
+++ b/src/main/resources/Keymap_EmacsPlus.xml
@@ -68,6 +68,9 @@
     <keyboard-shortcut first-keystroke="ESCAPE" second-keystroke="PERIOD"/>
     <mouse-shortcut keystroke="control button1"/>
   </action>
+  <action id="Back">
+    <keyboard-shortcut first-keystroke="alt COMMA"/>
+  </action>
   <action id="GotoImplementation">
     <keyboard-shortcut first-keystroke="control U" second-keystroke="alt PERIOD"/>
   </action>
@@ -302,6 +305,7 @@
   </action>
   <action id="Emacs+.KillWordBackward">
     <keyboard-shortcut first-keystroke="alt DELETE"/>
+    <keyboard-shortcut first-keystroke="alt BACK_SPACE"/>
     <keyboard-shortcut first-keystroke="control BACK_SPACE"/>
     <keyboard-shortcut first-keystroke="ESCAPE" second-keystroke="DELETE"/>
     <!-- TODO: Temporary binding for backward kill sexp -->
@@ -497,7 +501,7 @@
     <!--<keyboard-shortcut first-keystroke="control shift BACK_SPACE"/>-->
   </action>
   <action id="EditorKillRegion">
-    <!--<keyboard-shortcut first-keystroke="control W"/>-->
+    <keyboard-shortcut first-keystroke="control W"/>
   </action>
   <action id="$Paste">
     <!--<keyboard-shortcut first-keystroke="alt P"/>-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -104,7 +104,7 @@
   </change-notes>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="191.4212.41"/>
+  <idea-version since-build="193"/>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->


### PR DESCRIPTION
Fix KeyboardQuit exception - I'm not sure what exactly is `setInjectedContext`, but the exception is pretty adamant that it shouldn't be in one: `TextComponentEditorAction is updated on EDT only and must not work in injected context`

Ensure `M-,` goes back to the previous mark before hitting `M-.`

Fix `C-w` for kill region.

Ensure 'M-backspace` deletes to the beginning of the word. 